### PR TITLE
Fixes instance username error

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -172,7 +172,7 @@ parts =
 recipe = plone.recipe.zope2instance
 http-address = 8080
 
-user = ${buildout:user}
+user=admin:admin
 zodb-cache-size = 3000
 
 zeo-address = ${zeoserver:zeo-address}


### PR DESCRIPTION
Instance throws an error after failing to parse user string.  Quick fix to provide default username:password to instance. 

