### PR TITLE
Override plone z3cforms

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -19,7 +19,7 @@ nmg.unmasked.views = git https://github.com/Sinar/nmg.unmasked.views
 politikus.extractives = git https://github.com/Sinar/politikus.extractives branch=main
 politikus.naturalresource = git https://github.com/Sinar/politikus.naturalresource branch=main
 odm.naturalresources = git https://github.com/Sinar/odm.naturalresources branch=main
-
+plone.app.z3cform  = git https://github.com/enfold/plone.app.z3cform branch=3.2.2+enfold1
 
 [buildout]
 
@@ -45,6 +45,7 @@ auto-checkout = politikus.contenttypes
                 politikus.extractives
                 politikus.naturalresource
                 odm.naturalresources
+                plone.app.z3cform
 
 
 ############################################
@@ -212,6 +213,7 @@ eggs =
     collective.vocabularies.iso
     celery[sqlalchemy]
     Products.PloneHotfix20210518
+    plone.app.z3cform
 
 ############################################
 # Versions Specification
@@ -228,6 +230,7 @@ eggs =
 
 collective.documentviewer = 6.0.0
 celery = 4.4.7
+plone.app.z3cform = 3.2.2+enfold1
 
 [zeoserver]
 recipe = plone.recipe.zeoserver


### PR DESCRIPTION
Use 3.2.2+enfold1 instead of plone core version.

Fixes https://github.com/Sinar/popolo.contenttypes/issues/14

Fixes https://github.com/Sinar/popolo.contenttypes/pull/58

Supersedes https://github.com/Sinar/popolo.contenttypes/pull/58